### PR TITLE
export computeBoundsFromCellContents as a named export

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import { calculateCellBoundaries as _calculateCellBoundaries } from "./calculateCellBoundaries"
+import { calculateCellBoundaries as _calculateCellBoundaries, computeBoundsFromCellContents } from "./calculateCellBoundaries"
 import type { InputRect as Cell, Line } from "./types"
 export type { Line, Cell }
 export { computeBoundsFromCellContents } from "./calculateCellBoundaries"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
-import { calculateCellBoundaries as _calculateCellBoundaries, computeBoundsFromCellContents } from "./calculateCellBoundaries"
+import { calculateCellBoundaries as _calculateCellBoundaries } from "./calculateCellBoundaries"
 import type { InputRect as Cell, Line } from "./types"
+export { computeBoundsFromCellContents } from "./calculateCellBoundaries"
 export type { Line, Cell }
 export { computeBoundsFromCellContents } from "./calculateCellBoundaries"
 


### PR DESCRIPTION
## Test failing in core 

<img width="1333" height="388" alt="image" src="https://github.com/user-attachments/assets/3e7833ca-2c59-4c69-847c-0a894774ab02" />
https://github.com/tscircuit/core/actions/runs/26796847935/job/78995178477?pr=2372

## Function used in core
<img width="579" height="252" alt="image" src="https://github.com/user-attachments/assets/157e9804-93db-4c2f-84a2-e9c327c05cbe" />

